### PR TITLE
Modify: books 앱 모델의 참조관계 수정

### DIFF
--- a/books/migrations/0001_initial.py
+++ b/books/migrations/0001_initial.py
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
                 ('total_price', models.IntegerField()),
                 ('content_type', models.CharField(max_length=50)),
                 ('content_info', models.TextField()),
-                ('status_code', models.IntegerField()),
+                ('status_code', models.ForeignKey('BookStatus', on_delete=models.CASCADE)),
                 ('place', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='places.place')),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='users.user')),
             ],
@@ -42,7 +42,6 @@ class Migration(migrations.Migration):
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
                 ('status', models.CharField(max_length=50)),
-                ('book', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='books.book')),
             ],
             options={
                 'db_table': 'book_statuses',

--- a/books/models.py
+++ b/books/models.py
@@ -14,13 +14,12 @@ class Book(TimeStampedModel):
     total_price  = models.IntegerField()
     content_type = models.CharField(max_length=50)
     content_info = models.TextField()
-    status_code  = models.IntegerField()
+    status_code  = models.ForeignKey('BookStatus', on_delete=models.CASCADE)
     
     class Meta:
         db_table = 'books'
         
 class BookStatus(TimeStampedModel):
-    book   = models.ForeignKey(Book, on_delete=models.CASCADE)
     status = models.CharField(max_length=50)
     
     class Meta:


### PR DESCRIPTION
- Book class의 status_code를 BookStatus의 FK로 설정
- BookStatus의 book_id FK는 삭제
- 예약건에 따른 예약 상태를 나타내기 위함

- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 예약(books)과 예약상태(book_statuses) 테이블 관계를 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. books app의 Book 모델 클래스
- status_code 필드를 정수타입이 아닌 FK로 만들어서 BookStatus와 연결

2. books app의 BookStatus 모델 클래스
- Book 모델 클래스를 참조하는 book_id 필드를 삭제

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 실수로 일대다 테이블 관계에서 FK의 위치를 잘못 지정했습니다.

<br />

## :: 기타 질문 및 특이 사항
- migrate했을때 DB에는 바로 적용이 되었지만, django 에러가 나고 완료가 되지 않아 어쩔수 없이 migrations 파일을 수정하여 migrate 했습니다.
