### PR TITLE
Add: 카카오 회원가입 및 로그인 기능 구현

### DIFF
--- a/nosleepplace/urls.py
+++ b/nosleepplace/urls.py
@@ -16,5 +16,6 @@ Including another URLconf
 from django.urls import path,include
 
 urlpatterns = [
-    path('places', include('places.urls'))
+    path('places', include('places.urls')),
+    path('users', include('users.urls')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,7 @@ Django==3.2.7
 django-cors-headers==3.10.0
 
 mysqlclient==2.0.3
+
+pyjwt==2.3.0
+
+requests==2.26.0

--- a/users/kakao.py
+++ b/users/kakao.py
@@ -1,0 +1,17 @@
+import requests
+
+from django.http import JsonResponse
+
+class KakaoAPI:
+    def __init__(self, access_token):
+        self.access_token = access_token
+        self.user_url     = 'https://kapi.kakao.com/v2/user/me'
+
+    def get_kakao_user(self):
+        headers  = {"Authorization": f"Bearer {self.access_token}"}
+        response = requests.post(self.user_url, headers=headers, timeout=3)
+
+        if not response.status_code == 200:
+            return JsonResponse({'message':"INVALID_KAKAO_TOKEN"}, status=401)
+
+        return response.json()

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,62 @@
-from django.test import TestCase
+import json, jwt
+from unittest.mock         import MagicMock, patch
 
-# Create your tests here.
+from django.test           import TestCase, Client
+
+from users.models          import User
+from nosleepplace.settings import SECRET_KEY
+
+class KakaoSignUpTest(TestCase):
+    @patch("users.kakao.requests")
+    def test_kakao_signup_new_user_success(self, mocked_requests):
+        client = Client()
+        
+        class MockedResponse:
+            def __init__(self, status_code):
+                self.status_code = status_code
+    
+            def json(self):
+                return {
+                    "id" : "1204",
+                    "kakao_account" : {
+                        "profile" : {
+                            "nickname" : "승준",
+                            "thumbnail_image_url" : "http://k.kakaocdn.net/img_110x110.jpg"
+                        },
+                        "email_needs_agreement" : False,
+                        "email" : "dddsfa@sample.com",
+                        "age_range_needs_agreement" : False,
+                        "age_range" : "20-30"
+                    }
+                }
+
+        mocked_requests.post = MagicMock(return_value = MockedResponse(200))
+        headers              = {"Authorization" : "fake_kakao_token"}
+        response             = client.post("/users/account/kakao", **headers)
+        self.assertEqual(response.status_code, 200)
+
+        access_token = response.json()['access_token']
+        payload      = jwt.decode(access_token, SECRET_KEY, algorithms="HS256")
+        kakao_id     = User.objects.get(id=payload['id']).kakao_id
+        
+        self.assertEqual(kakao_id, "1204")
+
+    @patch("users.kakao.requests")
+    def test_kakao_signup_fail(self, mocked_requests):
+        client = Client()
+        
+        class MockedResponse:
+            def __init__(self,status_code):
+                self.status_code = status_code
+            
+            def json(self):
+                return {
+                    "status_code" : -401,
+                    "message" : "INVALID_KAKAO_TOKEN"
+                }
+                
+        mocked_requests.post = MagicMock(return_value = MockedResponse(200))
+        headers              = {"Authorization" : "fake_kakao_token"}
+        response             = client.post("/users/account/kakao", **headers)
+        
+        self.assertEqual(response.status_code, 400)

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from users.views import KakaoSignUpView
+
+urlpatterns = [
+    path('/account/kakao', KakaoSignUpView.as_view()),
+]

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,0 +1,24 @@
+import jwt
+
+from django.http    import JsonResponse
+
+from nosleepplace.settings import SECRET_KEY
+from users.models          import User
+
+def login_required(func):
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            access_token = request.headers.get('Authorization', None)
+            payload      = jwt.decode(access_token, SECRET_KEY, algorithms='HS256')
+            user         = User.objects.get(id=payload['id'])
+            request.user = user
+            
+        except jwt.DecodeError:
+            return JsonResponse({'MESSAGE' : 'INVALID_TOKEN'}, status=400)
+            
+        except User.DoesNotExist:
+            return JsonResponse({'MESSAGE' : 'INVALID_USER'}, status=400)
+        
+        return func(self, request, *args, **kwargs)
+    
+    return wrapper 

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,36 @@
-from django.shortcuts import render
+import json, requests, jwt
 
-# Create your views here.
+from django.http           import JsonResponse
+from django.views          import View
+
+from nosleepplace.settings import SECRET_KEY
+from users.models          import User
+from users.kakao           import KakaoAPI
+
+class KakaoSignUpView(View):
+    def post(self, request):
+        try:
+            kakao_token   = request.headers.get('Authorization')
+            kakao_user    = KakaoAPI(kakao_token).get_kakao_user()
+            kakao_account = kakao_user['kakao_account']
+
+            nickname      = kakao_account['profile']['nickname'],
+            profile_image = kakao_account['profile']['thumbnail_image_url']
+
+            user, created = User.objects.get_or_create(
+                kakao_id = kakao_user['id'],
+                defaults = {
+                    'nickname'     : nickname,
+                    'profile_image': profile_image,
+                    'email'        : kakao_account.get('email', ''),
+                    'age_range'    : kakao_account.get('age_range', '')
+                }
+            )
+
+            access_token = jwt.encode({'id':user.id}, SECRET_KEY, algorithm='HS256')
+            return JsonResponse({'access_token':access_token}, status=200)
+
+        except KeyError:
+            return JsonResponse({'message':"KEY_ERROR"}, status=400)
+        except ValueError:
+             return JsonResponse({'message':"VALUE_ERROR"}, status=400)


### PR DESCRIPTION
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 소셜 로그인을 이용한 회원가입 및 로그인 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 카카오 토큰을 받아서 카카오 API로 사용자 정보 요청
   - 카카오 API URL로 토큰을 보내어 해당 사용자의 정보를 받기

2. `get_or_create`로 기존 고객인지 판단
   - 기준은 kakao_id 로만 판단하고, 필수정보인 nickname과 image는 defaults 설정함
   - 신규회원이면 create하여 회원가입

3. 선택 동의에 따른 정보 수집
   - 사용자 정보 응답에서 email 혹은 age_range가 있는지 여부에 따라 DB에 추가
   
4.  유닛테스트 코드 작성
    - MagicMock과 patch를 활용해 unittest 진행
    - 성공 케이스: 1. 토큰을 생성후 전달 2. 다시 토큰을 받아서 DB에 유저를 확인 
    - 실패 케이스: 카카오에 요청시 토큰 확인이 안되는 경우

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 프론트-백엔드-카카오 통신 과정에서 디버깅을 하기 위해  `print(response)` 를 활용했고 어떤 부분이 문제였는지 파악 할 수 있었습니다.

- 카카오 API URL 주소는 https로 시작되는데 http와 어떤 차이인지 알아보고 싶습니다.

- 유닛테스트의 목적과 개념은 이해했지만, 구체적으로 어떻게 작동되는지는 아직 어렵습니다.

- 카카오 API를 따로 관리하기 위해 kakao.py 생성하여 KakaoAPI class 작성

<br />

## :: 기타 질문 및 특이 사항
-  선택 동의 정보 항목들은 if문으로 처리했는데 더 효율적인 방법이 있을 지 궁금합니다.

- 유닛테스트시 status_code 관련 attribute 에러가 계속 발생했는데,
 MockedResponse class 에 __init__으로 status_code 속성을 만들어주었습니다. 맞는 방법인지 스스로 의심이 갑니다..


## :: 테스트 결과 사진 

- 유닛테스트
<img width="930" alt="스크린샷 2021-10-23 오후 3 59 52" src="https://user-images.githubusercontent.com/72376931/138623524-aeabdad5-4713-4afc-8864-f379aa19430c.png">

- 카카오 소셜 로그인으로 회원가입
<img width="1489" alt="스크린샷 2021-10-23 오후 4 04 05" src="https://user-images.githubusercontent.com/72376931/138623519-03b1c6ba-72e5-423c-b0c5-6faa3fc1300c.png">
