### PR TITLE
Add: 캘린더 예약정보 전송 기능 추가

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -20,6 +20,13 @@ class Book(TimeStampedModel):
         db_table = 'books'
         
 class BookStatus(TimeStampedModel):
+    
+    class Status(models.IntegerChoices):
+        PENDING   = 1
+        CONFIRMED = 2
+        COMPLETED = 3
+        CANCELLED = 4
+
     status = models.CharField(max_length=50)
     
     class Meta:

--- a/places/tests.py
+++ b/places/tests.py
@@ -1,6 +1,11 @@
-from django.test import TestCase, Client, client
+import jwt
 
-from places.models import Menu, Category, Place, City, Host, Image
+from django.test           import TestCase, Client
+
+from nosleepplace.settings import SECRET_KEY
+from places.models         import Menu, Category, Place, City, Host, Image
+from users.models          import User
+from books.models          import Book, BookStatus
 
 class PlaceListTest(TestCase):
     def setUp(self):     
@@ -194,4 +199,120 @@ class PlaceDetailView(TestCase):
                 
             }     
             )
-        self.assertEqual(response.status_code, 200)       
+        self.assertEqual(response.status_code, 200)
+
+class PlaceCalendarTest(TestCase):
+    def setUp(self):
+        Menu.objects.create(
+            id   = 1,
+            name = '가정집',
+        )
+        
+        Category.objects.create(
+            id      = 1,
+            name    = '주택',
+            menu_id = 1,
+        )
+        
+        City.objects.create(
+            id   = 1,
+            name = '서울'
+        )
+        
+        Host.objects.create(
+            id   = 1,
+            name = '빌리',
+            profile_image = 'https://cdn.pixabay.com/photo/2017/07/10/11/28/bulldog-2489829_1280.jpg'
+        )
+        
+        Place.objects.create(
+            id            = 1,
+            name          = '마루비 성산 - 80년대 주택을 개조한 빈티지 스튜디오 1F ',
+            category_id   = 1,
+            host_id       = 1,
+            city_id       = 1,
+            price         = 66000,
+            minimum_time  = 2,
+            description   = '<p>마루비 동교에 이어 두번째 스튜디오를 만들었습니다. 이곳은 80년대 지어진 2층 단독 건물로 천장이 예쁘고 나무 루바로 된 벽이나 아치형 도어 등 요즘 주택에서 찾아보기 힘든 멋진 디테일이 있습니다. 바닥 및 가구는 고재 소나무 폐교마루를 시공해 제작하였으며 자연스럽지만 잘 정돈된 생활공간(1F)을 만들고자 하였습니다. <br><br>* 촬영가능시간 7-22시</p>',
+            capacity      = '기본 7명',
+            size          = '35평 / 116m²',
+            floor         = '지상 1층',
+            parking       = '주차 3대 가능',
+            location_info = '<p>\n주차는 단층 임대시 2대, 1-2층 통으로 임대 시 최대 6대까지 가능합니다. 조용한 성산동에 있으며 마포중앙도서관 걸어서 5분거리, 마포구청 걸어서 10분거리입니다. 식사는 중앙도서관 내 식당 이용하시는걸 추천드립니다.\n</p>'
+        )
+        
+        user = User.objects.create(
+            id            = 1,
+            kakao_id      = '1960067483',
+            nickname      = '성해호',
+            profile_image = 'http://k.kakaocdn.net/dn/cnv4DE/btq7DsQ0kM6/mTFyVTEeGMzEbakRv72iKK/img_110x110.jpg',
+            email         = 'soh308@nate.com',
+            age_range     = '30~39'
+        )
+        
+        BookStatus.objects.create(
+            id     = 1,
+            status = "대기" 
+        )
+        
+        Book.objects.create(
+            id             = 1,
+            user_id        = 1,
+            place_id       = 1,
+            date           = "2021-10-28",
+            start_time     = "2021-10-28T02:00:00",
+            end_time       = "2021-10-28T04:00:00",
+            head_count     = 3,
+            total_price    = 224000,
+            content_type   = "촬영 소개",
+            content_info   = "촬영 내용",
+            status_code_id = 1
+        )
+        
+        self.access_token = jwt.encode({'id':user.id}, SECRET_KEY, algorithm='HS256')
+        
+    def tearDown(self):
+        Place.objects.all().delete()
+        User.objects.all().delete()
+        Book.objects.all().delete()
+    
+    def test_place_calendar_get_success(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        response = client.get('/places/1/calendar?days=30&time=2021-10-21T12:00:00', **headers)
+        self.assertEqual(response.json(),
+            {
+                "result" : [
+                    {
+                        "start_time" : "2021-10-28T02:00:00",
+                        "end_time"   : "2021-10-28T04:00:00",
+                        "usage_time" : "2"
+                    }
+                ]
+            }
+        )
+        self.assertEqual(response.status_code, 200)
+    
+    def test_place_calendar_get_invalid_place_id_fail(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        response = client.get('/places/99/calendar?time=2021-10-21T12:00:00', **headers)
+        
+        self.assertEqual(response.json(),{"message":"INVALID_PLACE_ID"})
+        self.assertEqual(response.status_code, 404)
+        
+    def test_place_calendar_get_value_error_fail(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        response = client.get('/places/1/calendar?time=2021-10-21T12', **headers)
+        
+        self.assertEqual(response.json(),{"message":"VALUE_ERROR"})
+        self.assertEqual(response.status_code, 400)
+    
+    def test_place_calendar_get_type_error_fail(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        response = client.get('/places/1/calendar', **headers)
+        
+        self.assertEqual(response.json(),{"message":"TYPE_ERROR"})
+        self.assertEqual(response.status_code, 400)

--- a/places/urls.py
+++ b/places/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from places.views import PlaceListView, PlaceDetailView
+from places.views import PlaceListView, PlaceDetailView, PlaceCalendarView
 
 urlpatterns = [
     path('', PlaceListView.as_view()),
-    path('/<int:place_id>', PlaceDetailView.as_view())
+    path('/<int:place_id>', PlaceDetailView.as_view()),
+    path('/<int:place_id>/calendar', PlaceCalendarView.as_view())
 ]

--- a/places/views.py
+++ b/places/views.py
@@ -1,9 +1,12 @@
 import json
+from datetime             import datetime, timedelta
 
 from django.http.response import JsonResponse
 from django.views         import View
 
 from places.models        import Place
+from books.models         import Book, BookStatus
+from users.utils          import login_required
 
 class PlaceListView(View):    
     def get(self, request):
@@ -64,3 +67,36 @@ class PlaceDetailView(View):
         
         except ValueError:
             return JsonResponse({'message' : 'VALUE_ERROR'}, status=400)
+
+class PlaceCalendarView(View):
+    @login_required
+    def get(self, request, place_id):
+        try:
+            if not Place.objects.filter(id=place_id).exists():
+                return JsonResponse({"message":"INVALID_PLACE_ID"}, status=404)
+
+            time = request.GET.get('time', None)
+            days = int(request.GET.get('days', 60))
+
+            current_time = datetime.strptime(time, "%Y-%m-%dT%H:%M:%S")
+            day_limit    = (current_time + timedelta(days)).date()
+
+            books = Book.objects.filter(
+                place_id           = place_id,
+                status_code_id__in = [BookStatus.Status.PENDING.value, BookStatus.Status.CONFIRMED.value], 
+                start_time__gt     = current_time,
+                end_time__lt       = day_limit
+            )
+
+            result = [{
+                    'start_time' : book.start_time,
+                    'end_time'   : book.end_time,
+                    'usage_time' : str(book.end_time - book.start_time).split(":")[0]
+                } for book in books]
+            return JsonResponse({'result': result})
+
+        except ValueError:
+            return JsonResponse({'message':'VALUE_ERROR'}, status=400)
+
+        except TypeError:
+            return JsonResponse({'message':'TYPE_ERROR'}, status=400)


### PR DESCRIPTION
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 장소 스케쥴 캘린더에 이미 예약된 시간대를 보여주기 위함

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 전송할 예약정보 조건
- 쿼리 파라미터로 현재시간과 기간 정보을 받음
- 기간내 현재시간 이후의 예약이 있을 시 데이터를 전송함
- 예약상태가 대기, 확정인 경우에만 전송함 (취소 및 완료 예약은 제외)
- 해당 데이터가 없으면 빈배열 반환

2. 함수 단위 유닛 테스트
- 테스트 코드 작성 및 수행 확인 완료

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- datetime, date, timedelta를 이용해 날짜 데이터를 다룰 수 있습니다.
- strptime, strftime 등 메서드를 활용할 수 있습니다.
- 파이썬의 enum class 개념을 배웠고 django model에 IntegerChoices를 적용해보았습니다.

<br />

## :: 기타 질문 및 특이 사항
- filter 내부의 조건이 많은데 가독성을 위해 분리해야 할지 고민입니다. 
