### PR TITLE
Add: 장소별 예약 신청 및 조회 기능

### DIFF
--- a/books/tests.py
+++ b/books/tests.py
@@ -1,3 +1,238 @@
-from django.test import TestCase
+import jwt
 
-# Create your tests here.
+from django.test           import TestCase, Client
+
+from users.models          import User
+from places.models         import Menu, Category, City, Host, Place, Image
+from books.models          import Book, BookStatus
+from nosleepplace.settings import SECRET_KEY
+
+class BookPlaceTest(TestCase):
+    def setUp(self):
+        Menu.objects.create(
+            id   = 1,
+            name = '가정집',
+        )
+
+        Category.objects.create(
+            id      = 1,
+            name    = '주택',
+            menu_id = 1,
+        )
+
+        City.objects.create(
+            id   = 1,
+            name = '서울'
+        )
+
+        Host.objects.create(
+            id            = 1,
+            name          = '빌리',
+            profile_image = 'https://cdn.pixabay.com/photo/2017/07/10/11/28/bulldog-2489829_1280.jpg'
+        )
+
+        Place.objects.create(
+            id            = 1,
+            name          = '마루비 성산 - 80년대 주택을 개조한 빈티지 스튜디오 1F ',
+            category_id   = 1,
+            host_id       = 1,
+            city_id       = 1,
+            price         = 66000,
+            minimum_time  = 2,
+            description   = '<p>마루비 동교에 이어 두번째 스튜디오를 만들었습니다. 이곳은 80년대 지어진 2층 단독 건물로 천장이 예쁘고 나무 루바로 된 벽이나 아치형 도어 등 요즘 주택에서 찾아보기 힘든 멋진 디테일이 있습니다. 바닥 및 가구는 고재 소나무 폐교마루를 시공해 제작하였으며 자연스럽지만 잘 정돈된 생활공간(1F)을 만들고자 하였습니다. <br><br>* 촬영가능시간 7-22시</p>',
+            capacity      = '기본 7명',
+            size          = '35평 / 116m²',
+            floor         = '지상 1층',
+            parking       = '주차 3대 가능',
+            location_info = '<p>\n주차는 단층 임대시 2대, 1-2층 통으로 임대 시 최대 6대까지 가능합니다. 조용한 성산동에 있으며 마포중앙도서관 걸어서 5분거리, 마포구청 걸어서 10분거리입니다. 식사는 중앙도서관 내 식당 이용하시는걸 추천드립니다.\n</p>'
+        )
+        
+        Image.objects.create(
+            url      = "https://images.unsplash.com/photo-1536437075651-01d675529a6b?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2340&q=80",
+            place_id = 1
+        )
+        
+        user = User.objects.create(
+            id            = 1,
+            kakao_id      = '1960067483',
+            nickname      = '성해호',
+            profile_image = 'http://k.kakaocdn.net/dn/cnv4DE/btq7DsQ0kM6/mTFyVTEeGMzEbakRv72iKK/img_110x110.jpg',
+            email         = 'soh308@nate.com',
+            age_range     = '30~39'
+        )
+        
+        self.access_token = jwt.encode({'id':user.id}, SECRET_KEY, algorithm='HS256')
+        
+        BookStatus.objects.bulk_create([
+            BookStatus(
+                id     = 1,
+                status = "PENDING"
+            ),
+            BookStatus(
+                id     = 2,
+                status = "CONFIRMED"
+            )
+        ])
+
+        Book.objects.bulk_create([
+            Book(
+                id             = 1,
+                user_id        = 1,
+                place_id       = 1,
+                date           = "2021-12-11",
+                start_time     = "2021-12-11T02:00:00",
+                end_time       = "2021-12-11T04:00:00",
+                head_count     = 3,
+                total_price    = 132000,
+                content_type   = "기존 예약 샘플",
+                content_info   = "기존 예약 샘플",
+                status_code_id = 1
+            ),
+            Book(
+                id             = 2,
+                user_id        = 1,
+                place_id       = 1,
+                date           = "2021-12-10",
+                start_time     = "2021-12-10T02:00:00",
+                end_time       = "2021-12-10T04:00:00",
+                head_count     = 5,
+                total_price    = 132000,
+                content_type   = "확정 예약 샘플",
+                content_info   = "확정 예약 샘플",
+                status_code_id = 2
+            )
+        ])
+        
+    def tearDown(self):
+        Place.objects.all().delete()
+        User.objects.all().delete()
+        BookStatus.objects.all().delete()
+    
+    def test_book_place_post_success(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        data     = {
+            "place_id"     : 1,
+            "start_time"   : "2021-10-30T03:00:00",
+            "end_time"     : "2021-10-30T05:00:00",
+            "head_count"   : 4,
+            "total_price"  : 132000,
+            "content_type" : "sample",
+            "content_info" : "sample"
+        }
+        response = client.post('/books', data=data, content_type='application/json', **headers)
+        
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(response.json(), {'message':'SUCCESS'})
+    
+    def test_book_place_post_invalid_place_fail(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        data     = {
+            "place_id"     : 99,
+            "start_time"   : "2021-10-30T03:00:00",
+            "end_time"     : "2021-10-30T05:00:00",
+            "head_count"   : 4,
+            "total_price"  : 132000,
+            "content_type" : "sample",
+            "content_info" : "sample"
+        }
+        response = client.post('/books', data=data, content_type='application/json', **headers)
+        
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json(), {'message':'INVALID_PLACE'})
+
+    def test_book_place_post_invalid_book_time_fail(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        data     = {
+            "place_id"     : 1,
+            "start_time"   : "2021-12-30T03:00:00",
+            "end_time"     : "2021-10-30T05:00:00",
+            "head_count"   : 4,
+            "total_price"  : 132000,
+            "content_type" : "sample",
+            "content_info" : "sample"
+        }
+        response = client.post('/books', data=data, content_type='application/json', **headers)
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message':'INVALID_BOOK_TIME'})
+
+    def test_book_place_post_already_booked_time_fail(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        data     = {
+            "place_id"     : 1,
+            "start_time"   : "2021-12-11T02:00:00",
+            "end_time"     : "2021-12-11T04:00:00",
+            "head_count"   : 4,
+            "total_price"  : 132000,
+            "content_type" : "sample",
+            "content_info" : "sample"
+        }
+        response = client.post('/books', data=data, content_type='application/json', **headers)
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message':'ALREADY_BOOKED_TIME'})
+
+    def test_book_place_post_key_error_fail(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        data     = {
+            "start_time"   : "2021-10-30T02:00:00",
+            "end_time"     : "2021-10-30T04:00:00",
+            "head_count"   : 4,
+            "total_price"  : 132000,
+            "content_type" : "sample",
+            "content_info" : "sample"
+        }
+        response = client.post('/books', data=data, content_type='application/json', **headers)
+        
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message':'KEY_ERROR'})
+    
+    def test_book_place_get_success(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        response = client.get('/books?status=PENDING&status=CONFIRMED', content_type='application/json', **headers)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {
+            'result': [
+                {
+                    "book_id"      : 2,
+                    "name"         : "마루비 성산 - 80년대 주택을 개조한 빈티지 스튜디오 1F ",
+                    "image"        : "https://images.unsplash.com/photo-1536437075651-01d675529a6b?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2340&q=80",
+                    "content_type" : "확정 예약 샘플",
+                    "content_info" : "확정 예약 샘플",
+                    "head_count"   : 5,
+                    "start_time"   : "2021년 12월 10일 02:00",
+                    "end_time"     : "04:00",
+                    "usage_time"   : 2,
+                    "total_price"  : 132000,
+                    "status"       : "CONFIRMED"
+                },
+                {
+                    "book_id"      : 1,
+                    "name"         : "마루비 성산 - 80년대 주택을 개조한 빈티지 스튜디오 1F ",
+                    "image"        : "https://images.unsplash.com/photo-1536437075651-01d675529a6b?ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&ixlib=rb-1.2.1&auto=format&fit=crop&w=2340&q=80",
+                    "content_type" : "기존 예약 샘플",
+                    "content_info" : "기존 예약 샘플",
+                    "head_count"   : 3,
+                    "start_time"   : "2021년 12월 11일 02:00",
+                    "end_time"     : "04:00",
+                    "usage_time"   : 2,
+                    "total_price"  : 132000,
+                    "status"       : "PENDING"
+                }
+            ]
+        })
+
+    def test_book_place_get_type_error_fail(self):
+        client   = Client()
+        headers  = {'HTTP_Authorization' : self.access_token}
+        response = client.get('/books?stasds', content_type='application/json', **headers)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json(), {'message':'TYPE_ERROR'})

--- a/books/urls.py
+++ b/books/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from books.views import BookPlaceView
+
+urlpatterns = [
+    path('', BookPlaceView.as_view())
+]

--- a/books/views.py
+++ b/books/views.py
@@ -1,3 +1,89 @@
-from django.shortcuts import render
+import json
+from datetime               import datetime
+from json.decoder           import JSONDecodeError
 
-# Create your views here.
+from django.views           import View
+from django.http            import JsonResponse
+from django.db.models       import Q
+
+from books.models           import Book, BookStatus
+from places.models          import Place
+from users.utils            import login_required
+
+class BookPlaceView(View):
+    @login_required
+    def post(self, request):
+        try:
+            user       = request.user
+            data       = json.loads(request.body)
+            place_id   = data['place_id']
+            
+            if not Place.objects.filter(id=place_id).exists():
+                return JsonResponse({ "message":"INVALID_PLACE"}, status=404)
+            
+            start_time = datetime.strptime(data['start_time'],"%Y-%m-%dT%H:%M:%S")
+            end_time   = datetime.strptime(data['end_time'],"%Y-%m-%dT%H:%M:%S")
+            date       = start_time.date()
+
+            if end_time <= start_time:
+                return JsonResponse({"message":"INVALID_BOOK_TIME"}, status=400)
+
+            q1 = Q(start_time__gte=start_time) & Q(start_time__lt=end_time)
+            q2 = Q(end_time__gt=start_time) & Q(end_time__lte=end_time)
+            q3 = Q(start_time=start_time) & Q(end_time=end_time)           
+
+            if Book.objects.filter(place_id=place_id).filter(q1|q2|q3).exists():
+                return JsonResponse({"message":"ALREADY_BOOKED_TIME"}, status=400)
+
+            Book.objects.create(
+                place_id        = place_id,
+                user_id         = user.id,
+                start_time      = start_time,
+                end_time        = end_time,
+                date            = date,
+                head_count      = data['head_count'],
+                total_price     = data['total_price'],
+                content_type    = data['content_type'],
+                content_info    = data['content_info'],
+                status_code_id  = BookStatus.Status.PENDING.value
+            )
+            return JsonResponse({"message":"SUCCESS"}, status=201)
+
+        except JSONDecodeError:
+            return JsonResponse({"message":"JSON_DECODE_ERROR"}, status=400)
+        
+        except KeyError:
+            return JsonResponse({"message":"KEY_ERROR"}, status=400)
+
+    @login_required
+    def get(self, request):
+        try:
+            user   = request.user
+            
+            filter_prefixes = {
+                'status' : 'status_code__status__in'
+            }
+
+            filter_set = {filter_prefixes.get(key): value for (key, value) in dict(request.GET).items()}
+
+            books = Book.objects.filter(user_id=user.id, **filter_set).order_by('start_time')
+
+            result = [{
+                'book_id'      : book.id,
+                'name'         : book.place.name,
+                'image'        : book.place.image_set.first().url,
+                'content_type' : book.content_type,
+                'content_info' : book.content_info,
+                'head_count'   : book.head_count,
+                'start_time'   : datetime.strftime(book.start_time,"%Y년 %m월 %d일 %H:00"),
+                'end_time'     : datetime.strftime(book.end_time,"%H:00"),
+                'host_name'    : book.place.host.name,
+                'usage_time'   : int(book.total_price / book.place.price),
+                'total_price'  : book.total_price,
+                'status'       : book.status_code.status
+                } for book in books]
+
+            return JsonResponse({'result':result}, status=200)
+
+        except TypeError:
+            return JsonResponse({"message":"TYPE_ERROR"}, status=400)

--- a/nosleepplace/settings.py
+++ b/nosleepplace/settings.py
@@ -162,20 +162,20 @@ CORS_ALLOW_HEADERS = (
     'x-requested-with',
 ) 
 
-LOGGING = {
-    'disable_existing_loggers': False,
-    'version': 1,
-    'handlers': {
-        'console': {
-            'class': 'logging.StreamHandler',
-            'level': 'DEBUG',
-        },
-    },
-    'loggers': {
-        'django.db.backends': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': False,
-        },
-    },
-}
+# LOGGING = {
+#     'disable_existing_loggers': False,
+#     'version': 1,
+#     'handlers': {
+#         'console': {
+#             'class': 'logging.StreamHandler',
+#             'level': 'DEBUG',
+#         },
+#     },
+#     'loggers': {
+#         'django.db.backends': {
+#             'handlers': ['console'],
+#             'level': 'DEBUG',
+#             'propagate': False,
+#         },
+#     },
+# }

--- a/nosleepplace/urls.py
+++ b/nosleepplace/urls.py
@@ -18,4 +18,5 @@ from django.urls import path,include
 urlpatterns = [
     path('places', include('places.urls')),
     path('users', include('users.urls')),
+    path('books', include("books.urls"))
 ]


### PR DESCRIPTION
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 로그인 상태에서 장소별 예약 생성과 예약 조회 기능

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 장소별 예약 신청 기능
- 예약 시간 string 데이터는 datetime으로 변환
- 시간 순서가 정상인지, 기존 예약과 시간이 겹치지 않는지 검사
- 기본 BookStatus는 PENDING으로 DB에 저장

2. 사용자별 예약 현황 조회 기능
- 쿼리 파라미터로 status의 값을 받아서 예약 현황에 따른 데이터 전송
- filter_prefixes와 딕셔너리 컴프리헨션을 이용한 filter_set 작성
- 시간순으로 데이터 전송

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- datetime으로 시간 비교를 해보고, 중복 예약을 방지하는 로직을 구상해볼 수 있었습니다.
- enum class로 BookStatus를 db 접근 없이 바로 불러올 수 있습니다.
- 필터링 기능을 구현하며 딕셔너리 컴프리헨션을 활용해 더 확장성이 좋은 로직을 만들수 있습니다.

<br />

## :: 기타 질문 및 특이 사항
- 겹치는 예약을 걸러내는 로직을 만들며 q1, q2, q3으로 경우의 수를 나누었는데 이게 맞는 방법인지 더 명확한 조건식은 없을 지 고민입니다.

## :: 유닛 테스트 완료
![스크린샷 2021-10-28 오후 12 45 47](https://user-images.githubusercontent.com/72376931/139183098-29c8d169-b83a-488e-922b-e71fb8236ced.png)

